### PR TITLE
basically since you use a curl object which persists, so if you set the p

### DIFF
--- a/lib/transport/ElasticSearchTransportHTTP.php
+++ b/lib/transport/ElasticSearchTransportHTTP.php
@@ -209,8 +209,11 @@ class ElasticSearchTransportHTTP extends ElasticSearchTransport {
         curl_setopt($conn, CURLOPT_CUSTOMREQUEST, strtoupper($method));
         curl_setopt($conn, CURLOPT_FORBID_REUSE , 0) ;
 
-        if (is_array($payload) && count($payload) > 0)
+        if (is_array($payload) && count($payload) > 0) {
             curl_setopt($conn, CURLOPT_POSTFIELDS, json_encode($payload)) ;
+        } else {
+        	curl_setopt($conn, CURLOPT_POSTFIELDS, null);
+        }
 
         $data = curl_exec($conn);
         if ($data !== false)


### PR DESCRIPTION
basically since you use a curl object which persists, so if you set the payload in one request, but then do another request that doesn't have a payload the old payload was still being used. So I added a line to null the payload if none are sent.
