### PR TITLE
When using get($id) the type was included twice.

### DIFF
--- a/src/ElasticSearch/Client.php
+++ b/src/ElasticSearch/Client.php
@@ -121,7 +121,7 @@ class Client {
      * @param mixed $id Optional
      */
     public function get($id, $verbose=false) {
-        return $this->request(array($this->type, $id), "GET");
+        return $this->request($id), "GET");
     }
 
     /**


### PR DESCRIPTION
Fixed "$es->get($id)" so it doesn't include the type twice.
