### PR TITLE
Correct the documentation for connection configuration.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -77,7 +77,7 @@ Using an array for configuration also works
 ```php
 <?php
 $es = Client::connection(array(
-    'server' => '127.0.0.1:9200',
+    'servers' => '127.0.0.1:9200',
     'protocol' => 'http',
     'index' => 'myindex',
     'type' => 'mytype'


### PR DESCRIPTION
The documentation currently specifies:

``` php
<?php
$es = Client::connection(array(
    'server' => '127.0.0.1:9200',
    'protocol' => 'http',
    'index' => 'myindex',
    'type' => 'mytype'
));
```

But the correct config key according to the code is `servers`. Might save someone else a few minutes of grokking :)
