### PR TITLE
PHPDoc comments and some wrong class names corrected

### DIFF
--- a/src/ElasticSearch/Client.php
+++ b/src/ElasticSearch/Client.php
@@ -36,8 +36,8 @@ class Client {
     /**
      * Construct search client
      *
-     * @return ElasticSearch\Client
-     * @param ElasticSearch\Transport\Transport $transport
+     * @return \ElasticSearch\Client
+     * @param \ElasticSearch\Transport\Base $transport
      * @param string $index
      * @param string $type
      */
@@ -56,7 +56,8 @@ class Client {
      *   - _port_
      *   - _index_
      *   - _type_
-     * @return ElasticSearch\Client
+     * @throws \Exception
+     * @return \ElasticSearch\Client
      */
     public static function connection($config = array()) {
         if (!$config && ($url = getenv('ELASTICSEARCH_URL'))) {
@@ -81,6 +82,10 @@ class Client {
         return $client;
     }
 
+    /**
+     * @param array|null $config
+     * @return array|void
+     */
     public function config($config = null) {
         if (!$config)
             return $this->_config;
@@ -90,7 +95,7 @@ class Client {
 
     /**
      * Change what index to go against
-     * @return void
+     * @return \ElasticSearch\Client
      * @param mixed $index
      */
     public function setIndex($index) {
@@ -103,7 +108,7 @@ class Client {
 
     /**
      * Change what types to act against
-     * @return void
+     * @return \ElasticSearch\Client
      * @param mixed $type
      */
     public function setType($type) {
@@ -119,6 +124,7 @@ class Client {
      *
      * @return array
      * @param mixed $id Optional
+     * @param bool $verbose
      */
     public function get($id, $verbose=false) {
         return $this->request($id, "GET");
@@ -128,6 +134,9 @@ class Client {
      * Puts a mapping on index
      *
      * @param array|object $mapping
+     * @param array $config
+     * @throws Exception
+     * @return array
      */
     public function map($mapping, array $config = array()) {
         if (is_array($mapping)) $mapping = new Mapping($mapping);
@@ -190,7 +199,8 @@ class Client {
      * Perform search, this is the sweet spot
      *
      * @return array
-     * @param array $document
+     * @param $query
+     * @param array $options
      */
     public function search($query, array $options = array()) {
         $start = microtime(true);

--- a/src/ElasticSearch/DSL/Builder.php
+++ b/src/ElasticSearch/DSL/Builder.php
@@ -32,11 +32,11 @@ class Builder {
     private $query = null;
     private $facets = null;
     private $sort = null;
-    
+
     /**
      * Construct DSL object
      *
-     * @return ElasticSearchDSL
+     * @return \ElasticSearch\DSL\Builder
      * @param array $options
      */
     public function __construct(array $options=array()) {
@@ -47,11 +47,11 @@ class Builder {
     /**
      * Add array clause, can only be one
      *
-     * @return ElasticSearchDSLBuilderQuery
+     * @return \ElasticSearch\DSL\Query
      * @param array $options
      */
     public function query(array $options=array()) {
-        if (!($this->query instanceof ElasticSearchDSLBuilderQuery))
+        if (!($this->query instanceof Query))
             $this->query = new Query($options);
         return $this->query;
     }
@@ -59,6 +59,7 @@ class Builder {
     /**
      * Build the DSL as array
      *
+     * @throws \ElasticSearch\Exception
      * @return array
      */
     public function build() {
@@ -68,7 +69,7 @@ class Builder {
         if ($this->size != null)
             $built['size'] = $this->size;
         if (!$this->query)
-            throw new Exception("Query must be specified");
+            throw new \ElasticSearch\Exception("Query must be specified");
         else
             $built['query'] = $this->query->build();
         return $built;

--- a/src/ElasticSearch/DSL/Query.php
+++ b/src/ElasticSearch/DSL/Query.php
@@ -21,7 +21,10 @@ namespace ElasticSearch\DSL;
  */
 class Query {
     protected $term = null;
-    protected $range = null;
+    /**
+     * @var RangeQuery
+     */
+    protected $range;
     protected $prefix = null;
     protected $wildcard = null;
     protected $matchAll = null;
@@ -33,13 +36,13 @@ class Query {
 
     public function __construct(array $options=array()) {
     }
-    
+
     /**
      * Add a term to this query
      *
-     * @return ElasticSearchDSL
+     * @return \ElasticSearch\DSL\Query
      * @param string $term
-     * @param string $field
+     * @param bool|string $field
      */
     public function term($term, $field=false) {
         $this->term = ($field)
@@ -47,13 +50,13 @@ class Query {
             : $term;
         return $this;
     }
-    
+
     /**
      * Add a wildcard to this query
      *
-     * @return ElasticSearchDSL
-     * @param string $term
-     * @param string $field
+     * @return \ElasticSearch\DSL\Query
+     * @param $val
+     * @param bool|string $field
      */
     public function wildcard($val, $field=false) {
         $this->wildcard = ($field)
@@ -65,7 +68,7 @@ class Query {
     /**
      * Add a range query
      *
-     * @return ElasticSearchDSLBuilderRangeQuery
+     * @return \ElasticSearch\DSL\RangeQuery
      * @param array $options
      */
     public function range(array $options=array()) {

--- a/src/ElasticSearch/DSL/RangeQuery.php
+++ b/src/ElasticSearch/DSL/RangeQuery.php
@@ -31,7 +31,7 @@ class RangeQuery {
     /**
      * Construct new RangeQuery component
      *
-     * @return ElasticSearchDSLBuilderRangeQuery
+     * @return \ElasticSearch\DSL\RangeQuery
      * @param array $options
      */
     public function __construct(array $options=array()) {
@@ -46,37 +46,59 @@ class RangeQuery {
     /**
      * Setters
      *
-     * @return ElasticSearchDSLBuilderRangeQuery 
+     * @return \ElasticSearch\DSL\RangeQuery
      * @param mixed $value
      */
     public function fieldname($value) {
         $this->fieldname = $value;
         return $this;
     }
+
+    /**
+     * @param $value
+     * @return \ElasticSearch\DSL\RangeQuery $this
+     */
     public function from($value) {
         $this->from = $value;
         return $this;
     }
+    /**
+     * @param $value
+     * @return \ElasticSearch\DSL\RangeQuery $this
+     */
     public function to($value) {
         $this->to = $value;
         return $this;
     }
+    /**
+     * @param $value
+     * @return \ElasticSearch\DSL\RangeQuery $this
+     */
     public function includeLower($value) {
         $this->includeLower = $value;
         return $this;
     }
+    /**
+     * @param $value
+     * @return \ElasticSearch\DSL\RangeQuery $this
+     */
     public function includeUpper($value) {
         $this->includeUpper = $value;
         return $this;
     }
+    /**
+     * @param $value
+     * @return \ElasticSearch\DSL\RangeQuery $this
+     */
     public function boost($value) {
         $this->boost = $value;
         return $this;
     }
-    
+
     /**
      * Build to array
      *
+     * @throws \ElasticSearch\Exception
      * @return array
      */
     public function build() {
@@ -88,7 +110,7 @@ class RangeQuery {
                     $built[$this->fieldname][$opt] = $this->$opt;
             }
             if (count($built[$this->fieldname]) == 0)
-                throw new Exception("Empty RangeQuery cant be created");
+                throw new \ElasticSearch\Exception("Empty RangeQuery cant be created");
         }
         return $built;
     }

--- a/src/ElasticSearch/Mapping.php
+++ b/src/ElasticSearch/Mapping.php
@@ -19,7 +19,9 @@ class Mapping {
     /**
      * Build mapping data
      *
-     * @return ElasticSearch\Mapping
+     * @param array $properties
+     * @param array $config
+     * @return \ElasticSearch\Mapping
      */
     public function __construct(array $properties = array(), array $config = array()) {
         $this->properties = $properties;
@@ -52,9 +54,11 @@ class Mapping {
 
     /**
      * Get or set a config
-     * 
+     *
      * @param string $key
      * @param mixed $value
+     * @throws \Exception
+     * @return array|void
      */
     public function config($key, $value = null) {
         if (is_array($key))

--- a/src/ElasticSearch/Transport/Base.php
+++ b/src/ElasticSearch/Transport/Base.php
@@ -63,7 +63,8 @@ abstract class Base {
      *
      * @param string|array $path
      * @param string $method
-     * @param array|false $payload
+     * @param array|bool $payload
+     * @return
      */
     abstract public function request($path, $method="GET", $payload=false);
 
@@ -78,16 +79,17 @@ abstract class Base {
      * @param array|string $query
      */
     abstract public function search($query);
-    
+
     /**
      * Search
      *
      * @return array
      * @param mixed $query String or array to use as criteria for delete
      * @param array $options Parameters to pass to delete action
+     * @throws \Elasticsearch\Exception
      */
     public function deleteByQuery($query, array $options = array()) {
-        throw new Exception(__FUNCTION__ . ' not implemented for ' . __CLASS__);
+        throw new \Elasticsearch\Exception(__FUNCTION__ . ' not implemented for ' . __CLASS__);
     }
 
     /**
@@ -110,7 +112,7 @@ abstract class Base {
      * Build a callable url
      *
      * @return string
-     * @param array $path
+     * @param array|bool $path
      * @param array $options Query parameter options to pass
      */
     protected function buildUrl($path = false, array $options = array()) {

--- a/src/ElasticSearch/Transport/HTTP.php
+++ b/src/ElasticSearch/Transport/HTTP.php
@@ -33,25 +33,27 @@ class HTTP extends Base {
         parent::__construct($host, $port);
         $this->ch = curl_init();
     }
-    
+
     /**
      * Index a new document or update it if existing
      *
      * @return array
      * @param array $document
      * @param mixed $id Optional
+     * @param array $options
      */
     public function index($document, $id=false, array $options = array()) {
         $url = $this->buildUrl(array($this->type, $id), $options);
         $method = ($id == false) ? "POST" : "PUT";
         return $this->call($url, $method, $document);
     }
-    
+
     /**
      * Search
      *
      * @return array
-     * @param mixed $id Optional
+     * @param array|string $query
+     * @param array $options
      */
     public function search($query, array $options = array()) {
         if (is_array($query)) {
@@ -74,12 +76,12 @@ class HTTP extends Base {
         }
         return $result;
     }
-    
+
     /**
      * Search
      *
      * @return array
-     * @param mixed $id Optional
+     * @param mixed $query
      * @param array $options Parameters to pass to delete action
      */
     public function deleteByQuery($query, array $options = array()) {
@@ -105,7 +107,7 @@ class HTTP extends Base {
         }
         return !isset($result['error']) && $result['ok'];
     }
-    
+
     /**
      * Perform a request against the given path/method/payload combination
      * Example:
@@ -113,7 +115,7 @@ class HTTP extends Base {
      *
      * @param string|array $path
      * @param string $method
-     * @param array|false $payload
+     * @param array|bool $payload
      * @return array
      */
     public function request($path, $method="GET", $payload=false) {
@@ -133,14 +135,15 @@ class HTTP extends Base {
         else
             return $this->request(false, "DELETE");
     }
-    
+
     /**
      * Perform a http call against an url with an optional payload
      *
      * @return array
      * @param string $url
      * @param string $method (GET/POST/PUT/DELETE)
-     * @param array $payload The document/instructions to pass along
+     * @param array|bool $payload The document/instructions to pass along
+     * @throws HTTPException
      */
     protected function call($url, $method="GET", $payload=false) {
         $conn = $this->ch;

--- a/src/ElasticSearch/Transport/Memcached.php
+++ b/src/ElasticSearch/Transport/Memcached.php
@@ -20,17 +20,19 @@ class Memcached extends Base {
         $this->conn = new Memcache;
         $this->conn->connect($host, $port);
     }
-    
+
     /**
      * Index a new document or update it if existing
      *
      * @return array
      * @param array $document
      * @param mixed $id Optional
+     * @param array $options
+     * @throws \ElasticSearch\Exception
      */
     public function index($document, $id=false, array $options = array()) {
         if ($id === false)
-            throw new Exception("Memcached transport requires id when indexing");
+            throw new \ElasticSearch\Exception("Memcached transport requires id when indexing");
 
         $document = json_encode($document);
         $url = $this->buildUrl(array($this->type, $id));
@@ -39,12 +41,13 @@ class Memcached extends Base {
             'ok' => $response
         );
     }
-    
+
     /**
      * Search
      *
      * @return array
-     * @param mixed $id Optional
+     * @param array|string $query
+     * @throws \ElasticSearch\Exception
      */
     public function search($query) {
         if (is_array($query)) {
@@ -57,7 +60,7 @@ class Memcached extends Base {
                 $result = json_decode($this->conn->get($url), true);
                 return $result;
             }
-            throw new Exception("Memcached protocol doesnt support the full DSL, only query");
+            throw new \ElasticSearch\Exception("Memcached protocol doesnt support the full DSL, only query");
         }
         elseif (is_string($query)) {
             /**
@@ -70,7 +73,7 @@ class Memcached extends Base {
             return $result;
         }
     }
-    
+
     /**
      * Perform a request against the given path/method/payload combination
      * Example:
@@ -78,7 +81,7 @@ class Memcached extends Base {
      *
      * @param string|array $path
      * @param string $method
-     * @param array|false $payload
+     * @param array|bool $payload
      * @return array
      */
     public function request($path, $method="GET", $payload=false) {
@@ -93,11 +96,12 @@ class Memcached extends Base {
         }
         return json_decode($result);
     }
-    
+
     /**
      * Flush this index/type combination
      *
      * @return array
+     * @param mixed $id
      * @param array $options Parameters to pass to delete action
      */
     public function delete($id=false, array $options = array()) {


### PR DESCRIPTION
Corrected all PHPDoc comments to match the function signature in order to make code completion in IDEs work. Works for me now in PHPStorm.

Also fixed a bug where there was an incorrect classname in an instanceof call in Builder.php and some wrong Exception class names (unnamespaced Exception was changed to \ElasticSearch\Exception)

This commit should not modify or break any functionality.
