### PR TITLE
added debug handler: ElasticSearch\Client::addOnCallHandler

### DIFF
--- a/src/ElasticSearch/Client.php
+++ b/src/ElasticSearch/Client.php
@@ -274,4 +274,16 @@ class Client {
         }
         return compact('protocol', 'servers', 'index', 'type');
     }
+
+    /**
+     * Add a handler called every time a request is made to ElasticSearch
+     *
+     * @param callable $cb
+     * @return void
+     */
+    public function addOnCallHandler($cb)
+    {
+        $this->transport->onCall[] = $cb;
+    }
+
 }

--- a/src/ElasticSearch/Transport/Base.php
+++ b/src/ElasticSearch/Transport/Base.php
@@ -38,6 +38,13 @@ abstract class Base {
     protected $type;
 
     /**
+     * called on each request
+     * @var array f(url, method, payload, return)
+     */
+    public $onCall;
+
+
+    /**
      * Default constructor, just set host and port
      * @param string $host
      * @param int $port

--- a/src/ElasticSearch/Transport/HTTP.php
+++ b/src/ElasticSearch/Transport/HTTP.php
@@ -212,6 +212,13 @@ class HTTP extends Base {
             throw $exception;
         }
 
+        // callback
+        if ($this->onCall) {
+            foreach ($this->onCall as $cb) {
+                call_user_func($cb, $url, $method, $payload, $data);
+            }
+        }
+
         return $data;
     }
 }


### PR DESCRIPTION
It is possible to register a callback, which gets called every time a request to ElasticSearch is made.

It makes possible to create debug tools, such as this _debug bar_ for Nette Fw.
![debug bar example](https://f.cloud.github.com/assets/227416/605166/bc53a294-cd0c-11e2-97ad-f33e38e8579b.png)
