### PR TITLE
Reset Bulk operations while a new Bulk transaction is called.

### DIFF
--- a/src/ElasticSearch/Client.php
+++ b/src/ElasticSearch/Client.php
@@ -307,7 +307,9 @@ class Client {
      */
 
     public function beginBulk() {
-        if (!$this->bulk) {
+        if ($this->bulk) {
+            $this->bulk->reset();
+        } else {
             $this->bulk = $this->createBulk($this);
         }
         return $this->bulk;


### PR DESCRIPTION
Batches can have a limited memory. 
This hack allows requesting the bulk API several times with the same PHP object. 
```php
while($continue) {
  $elastic->begin();
  $rows = $pdo->query($query);
  foreach ($rows as $row)
    $elastic->index($row);
  $elastic->commit();
}
```