### PR TITLE
Global search aggregations issue.

### DIFF
--- a/src/ElasticSearch/Transport/HTTP.php
+++ b/src/ElasticSearch/Transport/HTTP.php
@@ -84,6 +84,15 @@ class HTTP extends Base {
             ));
             $result = $this->call($url, "POST", $options);
         }
+        else {
+            /**
+             * no http query string search
+             */
+            $url = $this->buildUrl(array(
+                $this->type, "_search?"
+            ));
+            $result = $this->call($url, "POST", $options);
+        }
         return $result;
     }
 


### PR DESCRIPTION
Don't send the Q parameter if the query is NULL.
Otherwise it should search only items with void word.

Now you can search a void word:
`$es->search("", $options);`
or you can search every things:
`$es->search(null, $options);`
