### PR TITLE
added support for preference

### DIFF
--- a/src/ElasticSearch/Transport/HTTP.php
+++ b/src/ElasticSearch/Transport/HTTP.php
@@ -65,14 +65,14 @@ class HTTP extends Base {
              * Array implies using the JSON query DSL
              */
             $arg = "_search";
-            if(isset($options['routing'])) {
-                $arg = "_search?routing=" . $options['routing'];
-            }
-            
-            $url = $this->buildUrl(array(
-                $this->type, $arg
-            ));
-            
+            /**
+             * $options may contain values like:
+             * $options['routing'] = 'user123'
+             * or
+             * $options['preference'] = 'xyzabc123'
+             */
+            $url = $this->buildUrl(array($this->type, $arg), $options);
+
             $result = $this->call($url, "GET", $query);
         }
         elseif (is_string($query)) {


### PR DESCRIPTION
Please merge added support for preference...
http://www.elasticsearch.org/guide/en/elasticsearch/reference/0.90/search-request-preference.html

The following Url will then be supported:
_search?routing=user123 (currently supported)
_search?preference=xyzABC
_search?search_type=query_and_fetch
