### PR TITLE
fix empty commit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.swp
 vendor
+.DS_Store

--- a/src/ElasticSearch/Client.php
+++ b/src/ElasticSearch/Client.php
@@ -326,7 +326,7 @@ class Client {
      */
 
     public function commitBulk() {
-        if ($this->bulk) {
+        if ($this->bulk && $this->bulk->count()) {
             $result = $this->bulk->commit();
             $this->bulk = null;
             return $result;


### PR DESCRIPTION
Prevent error 400 from ES, while  an empty bulk is committed
```php
$ack = $this->elastic->getClient()->commit();
var_dump($ack);
```
will output: 
```php
array(2) {
  ["error"]=>
  string(121) "ElasticsearchParseException[Failed to derive xcontent from org.elasticsearch.common.bytes.ChannelBufferBytesReference@29]"
  ["status"]=>
  int(400)
}
```