### PR TITLE
json_encode empty array from "[]" to "{}"

### DIFF
--- a/src/ElasticSearch/Transport/HTTP.php
+++ b/src/ElasticSearch/Transport/HTTP.php
@@ -176,7 +176,7 @@ class HTTP extends Base {
         curl_setopt($conn, CURLOPT_FORBID_REUSE , 0) ;
 
         if (is_array($payload) && count($payload) > 0)
-            curl_setopt($conn, CURLOPT_POSTFIELDS, json_encode($payload)) ;
+            curl_setopt($conn, CURLOPT_POSTFIELDS, json_encode($payload, JSON_FORCE_OBJECT)) ;
         else
 	       	curl_setopt($conn, CURLOPT_POSTFIELDS, $payload);
 


### PR DESCRIPTION
Outputs an object rather than an array when a non-associative array is used. Especially useful when the recipient of the output is expecting an object and the array is empty. Available since PHP 5.3.0

```json
"highlight": {
    "fields": {
      "content": {}
    }
  }
```