### PR TITLE
Improved HTTP transport errors from curl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.swp
 vendor
 .DS_Store
+composer.lock

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 *.swp
 vendor
 .DS_Store
+composer.phar
 composer.lock
+.vagrant/
+Vagrantfile

--- a/src/ElasticSearch/Transport/HTTP.php
+++ b/src/ElasticSearch/Transport/HTTP.php
@@ -218,8 +218,12 @@ class HTTP extends Base {
                     break;
                 default:
                     $error = "Unknown error";
-                    if ($errno == 0)
+                    if ($errno == 0) {
                         $error .= ". Non-cUrl error";
+                    } else {
+                        $errstr = curl_error($conn);
+                        $error .= " ($errstr)";
+                    }
                     break;
             }
             $exception = new HTTPException($error);


### PR DESCRIPTION
Included better error reports from curl calls since the previous way was a bit obscure. Also ignoring any kind of vagrant related files as well as composer.(`phar|lock`) in git ignore pattern.