### PR TITLE
Avoid double slashes in built url

### DIFF
--- a/src/ElasticSearch/Transport/Base.php
+++ b/src/ElasticSearch/Transport/Base.php
@@ -126,7 +126,7 @@ abstract class Base {
      */
     protected function buildUrl($path = false, array $options = array()) {
         $isAbsolute = (is_array($path) ? $path[0][0] : $path[0]) === '/';
-        $url = $isAbsolute ? '' : "/" . $this->index;
+        $url = $isAbsolute || null === $this->index ? '' : "/" . $this->index;
 
         if ($path && is_array($path) && count($path) > 0)
             $url .= "/" . implode("/", array_filter($path));


### PR DESCRIPTION
#### Bug
Using elasticsearch 5.3 and scroll API.
```php
$path = '_search/scroll';
$this->elasticsearch->setIndex(null)->setType(null);
$this->elasticsearch->request($path, 'POST', [
    'scroll' => '10m',
    'scroll_id' => $scrollId,
])
```
This was generating the following url: `//_search/scroll` with double slashes causing following error:
```json
{
    "error": {
        "root_cause": [
            {
                "type": "string_index_out_of_bounds_exception",
                "reason": "String index out of range: 0"
            }
        ],
        "type": "string_index_out_of_bounds_exception",
        "reason": "String index out of range: 0"
    },
    "status": 500
}
```

#### Solution
Avoid adding an extra slash when `$this->index` is null.