### PR TITLE
fixed starting request url from double slash

### DIFF
--- a/src/ElasticSearch/Transport/Base.php
+++ b/src/ElasticSearch/Transport/Base.php
@@ -128,12 +128,16 @@ abstract class Base {
         $isAbsolute = (is_array($path) ? $path[0][0] : $path[0]) === '/';
         $url = $isAbsolute || null === $this->index ? '' : "/" . $this->index;
 
-        if ($path && is_array($path) && count($path) > 0)
-            $url .= "/" . implode("/", array_filter($path));
-        if (substr($url, -1) == "/")
+        if ($path && is_array($path) && count($path) > 0) {
+            $path = implode("/", array_filter($path));
+            $url .= "/" . ltrim($path, '/');
+        }
+        if (substr($url, -1) === "/") {
             $url = substr($url, 0, -1);
-        if (count($options) > 0)
-          $url .= "?" . http_build_query($options, '', '&');
+        }
+        if (count($options) > 0) {
+            $url .= "?" . http_build_query($options, '', '&');
+        }
 
         return $url;
     }

--- a/src/ElasticSearch/Transport/HTTP.php
+++ b/src/ElasticSearch/Transport/HTTP.php
@@ -61,7 +61,7 @@ class HTTP extends Base {
      * @param array $options
      */
     public function update($partialDocument, $id, array $options = array()) {
-        $url = $this->buildUrl(array($this->type, $id), $options);
+        $url = $this->buildUrl(array($this->type, $id, '_update'), $options);
 
         return $this->call($url, "POST", array('doc' => $partialDocument));
     }


### PR DESCRIPTION
fixed double slash for second scrool request in version 5.6
url /_search/scroll transorms to //_search/scroll
https://www.elastic.co/guide/en/elasticsearch/reference/5.6/breaking_50_rest_api_changes.html#_strict_rest_query_string_parameter_parsing